### PR TITLE
feat(kolu): expose kaval-tui and padi-tui packages

### DIFF
--- a/config/home/tty/multiplexers/kolu.nix
+++ b/config/home/tty/multiplexers/kolu.nix
@@ -2,11 +2,15 @@
   pkgs,
   termInputs,
   ...
-}: {
+}: let
+  koluPackages = termInputs.kolu.packages.${pkgs.stdenvNoCC.hostPlatform.system};
+in {
   services.kolu = {
     enable = true;
-    # kolu isn't in nixpkgs — pull the binary from the flake input. Use termInputs
+    # kolu isn't in nixpkgs — pull the binaries from the flake input. Use termInputs
     # (not inputs) so OS-nixCfg's extraSpecialArgs.inputs doesn't shadow it.
-    package = termInputs.kolu.packages.${pkgs.stdenvNoCC.hostPlatform.system}.koluBin;
+    package = koluPackages.koluBin;
+    tuiPackage = koluPackages.kaval-tui;
+    padiTuiPackage = koluPackages.padi-tui;
   };
 }


### PR DESCRIPTION
## Summary
- Exposes two additional binaries from the `kolu` flake input, `kaval-tui` and `padi-tui`, alongside the existing `koluBin`.
- Wires them into `services.kolu.tuiPackage` / `services.kolu.padiTuiPackage`.

Unrelated to the WezTerm AI-agent work on other branches — split out as its own independent PR since it touches a different domain (tty multiplexer, not the GUI terminal).

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch` and confirm `kolu`/`kaval-tui`/`padi-tui` are on PATH