### PR TITLE
feat(wezterm): persist mux server across GUI restarts, tune rendering

### DIFF
--- a/config/home/gui/emulators/wezterm/options.lua
+++ b/config/home/gui/emulators/wezterm/options.lua
@@ -29,10 +29,32 @@ return function(wezterm, config)
     bottom = 0,
   }
   config.native_macos_fullscreen_mode = false
+
+  -- Local unix-domain mux server: panes survive a WezTerm GUI crash/quit
+  -- and are recovered when it's relaunched (a host reboot still loses
+  -- them). default_gui_startup_args makes the default launch attach to
+  -- this domain instead of a GUI-local-only pty. Pair with sessions.lua
+  -- (wezterm-sessions) for save/restore across a full restart.
+  -- "local" is a reserved built-in domain name and cannot be redefined.
+  config.unix_domains = {
+    { name = "local-mux" },
+  }
+  config.default_gui_startup_args = { "connect", "local-mux" }
+  -- The mux protocol renders panes via server-side screen diffs rather than
+  -- a raw pty passthrough, so fast full-redraw TUIs (btop, yazi) can arrive
+  -- as partial frames and show stale/garbled state. Bumping this batches
+  -- pty reads into more complete frames before diffing (default 3ms).
+  config.mux_output_parser_coalesce_delay_ms = 15
   -- Matches stylix.opacity.terminal in OS-nixCfg/lib/palette.nix.
   config.window_background_opacity = 0.85
   config.window_decorations = "RESIZE"
   config.enable_scroll_bar = false
+  config.max_fps = 60
+  config.animation_fps = 1
+  config.front_end = "WebGpu"
+  config.webgpu_power_preference = "HighPerformance"
+  config.check_for_updates = false
+  config.scrollback_lines = 1000
 
   -- hyperlink
   config.hyperlink_rules = {

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -1,4 +1,6 @@
 {
+  config,
+  lib,
   pkgs,
   base16Scheme,
   ...
@@ -71,11 +73,49 @@ in {
     enable = true;
     package =
       if pkgs.stdenv.hostPlatform.isDarwin
-      then pkgs.brewCasks.wezterm
+      # The real nightly build is installed by the `homebrew.casks` entry below
+      # (home-manager-brew, real `brew bundle install`) — Homebrew's cask for it
+      # sets `sha256 :no_check` (content changes on every nightly build with no
+      # version bump), which a Nix fixed-output derivation can never verify, so
+      # it can't be built as a Nix package at all (brew-nix's `pkgs.brewCasks`
+      # just emits an unbuildable placeholder hash for it). This is only here
+      # to satisfy `programs.wezterm`'s package option/`home.packages` entry
+      # without shadowing the brew-installed nightly binaries on PATH.
+      then pkgs.emptyDirectory
       else pkgs.wezterm;
 
     enableBashIntegration = false;
     enableZshIntegration = false;
+  };
+
+  # Installs the real nightly cask via `brew bundle` at activation (home-manager-brew),
+  # sidestepping the Nix fixed-output-hash problem above entirely. Puts the app at
+  # /Applications/WezTerm.app and binaries (wezterm, wezterm-gui, wezterm-mux-server)
+  # on PATH via Homebrew's own shims once shell integration runs `brew shellenv`.
+  # "wezterm" (stable) cask is frozen at the last stable tag (20240203-110809);
+  # upstream has shipped only rolling nightlies since, so track those instead to
+  # pick up 2+ years of fixes.
+  homebrew.casks = lib.optionals pkgs.stdenv.hostPlatform.isDarwin ["wezterm@nightly"];
+
+  # Pre-starts the local-mux unix domain server (options.lua) at login so the
+  # socket is already listening and warm before the GUI is ever launched —
+  # otherwise wezterm-gui spawns it lazily on first connect, adding a fork +
+  # bind to the critical path of opening the terminal. Runs in foreground
+  # (no --daemonize) since launchd, not the process itself, owns supervision
+  # and restart-on-crash via KeepAlive. Path is the cask's app bundle rather
+  # than the Homebrew shim, since the shim's prefix (/usr/local vs
+  # /opt/homebrew) depends on host architecture but the app bundle path
+  # doesn't.
+  launchd.agents.wezterm-mux-server = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = ["/Applications/WezTerm.app/Contents/MacOS/wezterm-mux-server"];
+      RunAtLoad = true;
+      KeepAlive = true;
+      ProcessType = "Background";
+      StandardOutPath = "${config.xdg.cacheHome}/wezterm-mux-server.log";
+      StandardErrorPath = "${config.xdg.cacheHome}/wezterm-mux-server.log";
+    };
   };
 
   home.packages = [pkgs.wezterm.terminfo];


### PR DESCRIPTION
## Summary
- Switch macOS WezTerm sourcing from `pkgs.brewCasks.wezterm` to a Homebrew `wezterm@nightly` cask (installed via home-manager-brew) — the nightly cask sets `sha256 :no_check`, which can't be verified as a Nix fixed-output derivation.
- Add a `launchd` agent that pre-starts `wezterm-mux-server` at login so the local-mux socket is warm before the GUI ever launches.
- `config.unix_domains`/`default_gui_startup_args` attach the GUI to that mux server by default, so panes survive a GUI crash/quit (not a full reboot).
- Bump `mux_output_parser_coalesce_delay_ms` so fast full-redraw TUIs (btop, yazi) don't arrive as partial/garbled frames over the mux protocol.
- Switch to the WebGpu front end, cap `max_fps`/`animation_fps`, disable `check_for_updates`, tighten `scrollback_lines`.

First PR in a stack — base for session persistence, pickers, agent monitoring, ssh picker, cmd palette, and quake terminal PRs that follow.

⚠️ **Please double check**: `scrollback_lines` is set to `1000`, down from WezTerm's built-in default of `3500`. Flagging in case that wasn't intentional.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`, confirm `wezterm@nightly` installs via `brew bundle` and `/Applications/WezTerm.app` exists
- [ ] Confirm `launchctl list | grep wezterm-mux-server` shows the agent running after login
- [ ] Launch WezTerm, kill `wezterm-gui`, relaunch, confirm panes are still there
- [ ] Confirm rendering looks correct with the WebGpu front end