### PR TITLE
feat(wezterm): add wezterm-sessions for save/restore across restarts

### DIFF
--- a/config/home/gui/emulators/wezterm/sessions.lua
+++ b/config/home/gui/emulators/wezterm/sessions.lua
@@ -1,0 +1,11 @@
+return function(wezterm, config)
+  local sessions = wezterm.plugin.require "https://github.com/abidibo/wezterm-sessions"
+
+  -- Save state under XDG data home rather than the plugin's git-clone cache
+  -- dir, so saved sessions survive `wezterm.plugin.update_all()`.
+  sessions.apply_to_config(config, {
+    auto_save_interval_s = 30,
+    git_branch_warn = true,
+    save_state_dir = "default-user-owned",
+  })
+end

--- a/config/home/gui/emulators/wezterm/wezterm.lua
+++ b/config/home/gui/emulators/wezterm/wezterm.lua
@@ -4,6 +4,7 @@ local config = wezterm.config_builder()
 require "options"(wezterm, config)
 require "binds"(wezterm, config)
 require "smartSplits"(wezterm, config)
+require "sessions"(wezterm, config)
 require "tabline"(wezterm, config)
 
 return config

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -67,7 +67,7 @@
 
   # We enumerate files individually (instead of a recursive symlink tree) so
   # the nix-generated colors/cyberpunk.toml can coexist without conflicts.
-  weztermFiles = ["binds.lua" "options.lua" "smartSplits.lua" "tabline.lua" "wezterm.lua"];
+  weztermFiles = ["binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "tabline.lua" "wezterm.lua"];
 in {
   programs.wezterm = {
     enable = true;


### PR DESCRIPTION
## Summary
- Adds `wezterm-sessions`, auto-saving session state every 30s.
- State saves to XDG data home (`save_state_dir = "default-user-owned"`) rather than the plugin's own git-clone cache dir, so it survives `wezterm.plugin.update_all()`.

Stacked on #40 (mux-persistence) — the local-mux domain there survives a GUI crash; this plugin survives a full host restart. Diff shown here is only this PR's slice.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`, confirm `sessions.lua` lands in `$XDG_CONFIG_HOME/wezterm/`
- [ ] Open a few tabs/panes, wait 30s+, restart WezTerm, confirm session restores