### PR TITLE
feat(wezterm): add zoxide-backed workspace picker, rebind tab chooser

### DIFF
--- a/config/home/gui/emulators/wezterm/binds.lua
+++ b/config/home/gui/emulators/wezterm/binds.lua
@@ -69,11 +69,36 @@ return function(wezterm, config)
       action = act.ActivateCopyMode,
     },
 
-    -- workspace chooser
+    -- workspace chooser/creator/rename now owned by workspacePicker.lua
+    -- (LEADER+W / LEADER+C / LEADER+R)
+
+    -- tab chooser/creator/rename: lowercase mirror of the workspace
+    -- bindings above, scoped to tabs instead of workspaces. Create is
+    -- LEADER+t (not the LEADER+c you'd expect from that mirror) because
+    -- LEADER+c is stack.wez's new-stacked-pane binding, in stackWez.lua.
     {
       mods = "LEADER",
       key = "w",
-      action = act.ShowLauncherArgs { flags = "WORKSPACES" },
+      action = act.ShowTabNavigator,
+    },
+
+    {
+      mods = "LEADER",
+      key = "t",
+      action = act.SpawnTab "CurrentPaneDomain",
+    },
+
+    {
+      mods = "LEADER",
+      key = "r",
+      action = act.PromptInputLine {
+        description = "Enter new name for tab",
+        action = wezterm.action_callback(function(window, _pane, line)
+          if line then
+            window:active_tab():set_title(line)
+          end
+        end),
+      },
     },
 
     -- C-S-l activates the debug overlay (implemented by default)

--- a/config/home/gui/emulators/wezterm/wezterm.lua
+++ b/config/home/gui/emulators/wezterm/wezterm.lua
@@ -5,6 +5,7 @@ require "options"(wezterm, config)
 require "binds"(wezterm, config)
 require "smartSplits"(wezterm, config)
 require "sessions"(wezterm, config)
+require "workspacePicker"(wezterm, config)
 require "tabline"(wezterm, config)
 
 return config

--- a/config/home/gui/emulators/wezterm/workspacePicker.lua
+++ b/config/home/gui/emulators/wezterm/workspacePicker.lua
@@ -1,0 +1,16 @@
+return function(wezterm, config)
+  local workspace_picker = wezterm.plugin.require "https://github.com/isseii10/workspace-picker.wezterm"
+
+  -- LEADER+W/C/R supersede the plain ShowLauncherArgs{WORKSPACES} binding
+  -- that used to live in binds.lua: LEADER+W opens the zoxide-backed
+  -- picker, LEADER+C creates a workspace manually, LEADER+R renames one.
+  -- Uppercase mirrors the lowercase LEADER+w/c/r tab equivalents in
+  -- binds.lua (switcher/create/rename), so the two are free to coexist.
+  workspace_picker.apply_to_config(config, {
+    keybinds = {
+      show_picker = { mods = "LEADER", key = "W" },
+      create_workspace = { mods = "LEADER", key = "C" },
+      rename_workspace = { mods = "LEADER", key = "R" },
+    },
+  })
+end

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -67,7 +67,7 @@
 
   # We enumerate files individually (instead of a recursive symlink tree) so
   # the nix-generated colors/cyberpunk.toml can coexist without conflicts.
-  weztermFiles = ["binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "tabline.lua" "wezterm.lua"];
+  weztermFiles = ["binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
 in {
   programs.wezterm = {
     enable = true;


### PR DESCRIPTION
## Summary
- Adds `workspace-picker.wezterm` on `LEADER+W` (zoxide-backed show picker), `LEADER+C` (create workspace), `LEADER+R` (rename workspace) — replaces `binds.lua`'s plain `ShowLauncherArgs{flags="WORKSPACES"}`.
- The freed lowercase `LEADER+w` now mirrors the workspace picker at the tab level (`ShowTabNavigator`), alongside new `LEADER+t` (spawn tab — not `LEADER+c`, which stack.wez claims in a later PR) and `LEADER+r` (rename tab).

Stacked on #41 (session persistence). Diff shown here is only this PR's slice.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`
- [ ] `LEADER+W/C/R` open/create/rename workspaces via the picker
- [ ] `LEADER+w/t/r` switch/create/rename tabs