### PR TITLE
feat(wezterm): add pane stacking and Claude-Code-aware agent monitoring

### DIFF
--- a/config/home/gui/emulators/wezterm/agentCards.lua
+++ b/config/home/gui/emulators/wezterm/agentCards.lua
@@ -1,0 +1,52 @@
+return function(wezterm, config)
+  local agent_deck = wezterm.plugin.require "https://github.com/Eric162/wezterm-agent-deck"
+
+  -- Vendored via home.file in wezterm.nix (not a wezterm.plugin.require
+  -- package — it's also a Claude Code plugin, installed by convention
+  -- under ~/.claude/plugins/). Skip quietly if it's not there yet, or if
+  -- WezTerm's Lua sandbox can't dofile it for any reason — this must never
+  -- break the rest of the config.
+  local plugin_root = os.getenv "HOME" .. "/.claude/plugins/wezterm-agent-cards"
+  local ok, agent_cards = pcall(dofile, plugin_root .. "/wezterm/init.lua")
+  if not ok then
+    return
+  end
+
+  -- hide_tab_bar = false keeps WezTerm's native tab bar (tabline.lua)
+  -- alongside the sidebar pane agent-cards spawns per-tab, instead of
+  -- letting apply_to_config's default (config.enable_tab_bar = false)
+  -- replace it.
+  config.keys = config.keys or {}
+  local before_count = #config.keys
+
+  agent_cards.apply_to_config(config, {
+    agent_deck = agent_deck,
+    sidebar_cols = 26,
+    hide_tab_bar = false,
+  })
+
+  -- apply_to_config unconditionally appends its own keybindings with no
+  -- option to omit individual ones. Strip the two sets that collide with
+  -- bindings this config already owns — only among the entries it just
+  -- added (by index), so pre-existing bindings from other modules are
+  -- never touched even if they happen to share a mods/key pair:
+  --  - ALT+1..9: herdr.nix's keys.focus_agent deliberately claims this
+  --    exact chord for its own inner-mux agent switching. ANY WezTerm-level
+  --    binding for a chord intercepts the keypress before it reaches the
+  --    pty, regardless of which entry wins — so these must be removed
+  --    outright, not just shadowed by a later binding.
+  --  - CTRL+SHIFT+d/e: sessions.lua's delete/edit-session bindings.
+  local blocked = { ["CTRL|SHIFT:d"] = true, ["CTRL|SHIFT:e"] = true }
+  for i = 1, 9 do
+    blocked["ALT:" .. i] = true
+  end
+
+  local kept = {}
+  for i, k in ipairs(config.keys) do
+    local id = (k.mods or "") .. ":" .. (k.key or "")
+    if not (i > before_count and blocked[id]) then
+      table.insert(kept, k)
+    end
+  end
+  config.keys = kept
+end

--- a/config/home/gui/emulators/wezterm/agentDeck.lua
+++ b/config/home/gui/emulators/wezterm/agentDeck.lua
@@ -1,0 +1,37 @@
+return function(wezterm, config)
+  local agent_deck = wezterm.plugin.require "https://github.com/Eric162/wezterm-agent-deck"
+
+  -- tab_title/right_status are disabled here because both agent-deck and
+  -- tabline.wez (tabline.lua) register their own format-tab-title and
+  -- update-status handlers, and WezTerm keeps only the LAST-registered
+  -- handler's output for each — tabline.lua loads after this module, so it
+  -- would silently clobber agent-deck's rendering every cycle. Detection
+  -- and notifications still run (agent-deck always registers an
+  -- update-status handler that polls panes, regardless of these flags);
+  -- tabline.lua reads agent_deck.get_agent_state()/get_status_icon() as a
+  -- custom component instead of letting agent-deck render itself.
+  --
+  -- If wezterm-agent-cards is vendored AND its own Claude Code plugin is
+  -- enabled (in whichever repo owns ~/.claude/settings.json — not this
+  -- one), its sidebar becomes the primary "does an agent need me" surface:
+  -- poll faster for its benefit, and drop agent-deck's own OS notifications
+  -- so the sidebar's waiting-state cue isn't duplicated. This is a cheap
+  -- file-existence check, not a real load — agentCards.lua does the actual
+  -- dofile and skips quietly if it's not there yet.
+  local agent_cards_present = (function()
+    local f = io.open(os.getenv "HOME" .. "/.claude/plugins/wezterm-agent-cards/wezterm/init.lua", "r")
+    if f then
+      f:close()
+      return true
+    end
+    return false
+  end)()
+
+  agent_deck.apply_to_config(config, {
+    icons = { style = "nerd" },
+    tab_title = { enabled = false },
+    right_status = { enabled = false },
+    update_interval = agent_cards_present and 500 or nil,
+    notifications = agent_cards_present and { enabled = false } or nil,
+  })
+end

--- a/config/home/gui/emulators/wezterm/stackWez.lua
+++ b/config/home/gui/emulators/wezterm/stackWez.lua
@@ -1,0 +1,68 @@
+return function(wezterm, config)
+  local stack = wezterm.plugin.require "https://github.com/bad-noodles/stack.wez"
+
+  -- enrich_tab_title disabled: stack.wez's built-in format-tab-title hook
+  -- would lose the same handler-registration race against tabline.lua that
+  -- agent-deck did (tabline.lua loads last and owns that event).
+  -- tabline.lua composes stack.stack_info() into its own tab components
+  -- instead. apply_to_config ignores its config argument entirely — it
+  -- only stores opts and doesn't touch config.keys, so keybindings are
+  -- added directly below via stack.action.*.
+  stack.apply_to_config(config, {
+    enrich_tab_title = false,
+  })
+
+  config.keys = config.keys or {}
+
+  -- New stacked pane, and step through the stack while staying zoomed.
+  -- Closing uses WezTerm's built-in CloseCurrentPane (already bound by
+  -- default) — stack.wez has no API for closing while preserving zoom.
+  -- LEADER+c claims the slot that would otherwise mirror LEADER+t
+  -- (tab create) — see the note in binds.lua's tab section.
+  table.insert(config.keys, { mods = "LEADER", key = "c", action = stack.action.SpawnPane })
+  table.insert(config.keys, { mods = "LEADER", key = "u", action = stack.action.ActivatePaneRelative(-1) })
+  table.insert(config.keys, { mods = "LEADER", key = "e", action = stack.action.ActivatePaneRelative(1) })
+
+  -- Fuzzy switcher across the active tab's panes (type to filter), for
+  -- when a stack has grown past a few panes and u/e stepping is too slow.
+  -- stack.wez has no picker of its own, so this is built directly on
+  -- InputSelector; it re-zooms afterward the same way
+  -- ActivatePaneRelative does, so it works whether or not the tab was
+  -- already zoomed into the stack.
+  table.insert(config.keys, {
+    mods = "LEADER",
+    key = "a",
+    action = wezterm.action_callback(function(window, pane)
+      local tab = window:active_tab()
+      local panes = tab:panes_with_info()
+      local choices = {}
+      for i, info in ipairs(panes) do
+        table.insert(choices, {
+          id = tostring(info.pane:pane_id()),
+          label = i .. ": " .. info.pane:get_title(),
+        })
+      end
+
+      window:perform_action(
+        wezterm.action.InputSelector {
+          title = "Switch Pane",
+          choices = choices,
+          fuzzy = true,
+          action = wezterm.action_callback(function(win, _pane, id)
+            if not id then
+              return
+            end
+            for _, info in ipairs(panes) do
+              if tostring(info.pane:pane_id()) == id then
+                tab:set_zoomed(false)
+                info.pane:activate()
+                tab:set_zoomed(true)
+              end
+            end
+          end),
+        },
+        pane
+      )
+    end),
+  })
+end

--- a/config/home/gui/emulators/wezterm/tabline.lua
+++ b/config/home/gui/emulators/wezterm/tabline.lua
@@ -1,5 +1,75 @@
 return function(wezterm, config)
   local tabline = wezterm.plugin.require "https://github.com/michaelbrusegard/tabline.wez"
+  local agent_deck = wezterm.plugin.require "https://github.com/Eric162/wezterm-agent-deck"
+  local stack = wezterm.plugin.require "https://github.com/bad-noodles/stack.wez"
+
+  -- agentDeck.lua disables agent-deck's own tab_title/right_status
+  -- rendering (it loses a handler-registration race against this plugin),
+  -- so its detected status is surfaced here instead, as plain tabline
+  -- components. tabline.wez's function-component slots only support plain
+  -- Text output (no per-status Foreground), so this loses agent-deck's
+  -- color coding — the icon shape (nerd style: working/waiting/idle/
+  -- inactive) is what distinguishes state here.
+  local function pane_status(pane_id)
+    local state = agent_deck.get_agent_state(pane_id)
+    return state and state.status or nil
+  end
+
+  -- Checks every pane in the tab, not just the active one — a background
+  -- pane in a split (e.g. Claude running behind an editor pane) still
+  -- needs to surface here. Mirrors agent-deck's own multi-pane example in
+  -- its README. Highest-priority status across the tab's panes wins.
+  local status_priority = { waiting = 3, working = 2, idle = 1 }
+
+  local function agent_tab_icon(tab)
+    local best = nil
+    for _, pane_info in ipairs(tab.panes or {}) do
+      local status = pane_status(pane_info.pane_id)
+      if status and (not best or (status_priority[status] or 0) > (status_priority[best] or 0)) then
+        best = status
+      end
+    end
+    if not best then
+      return ""
+    end
+    return agent_deck.get_status_icon(best) .. " "
+  end
+
+  local function agent_status_summary(window)
+    local counts = { waiting = 0, working = 0 }
+    local ok = pcall(function()
+      for _, mux_tab in ipairs(window:mux_window():tabs()) do
+        for _, p in ipairs(mux_tab:panes()) do
+          local status = pane_status(p:pane_id())
+          if status == "waiting" or status == "working" then
+            counts[status] = counts[status] + 1
+          end
+        end
+      end
+    end)
+    if not ok then
+      return ""
+    end
+
+    if counts.waiting > 0 then
+      return agent_deck.get_status_icon "waiting" .. counts.waiting
+    end
+    if counts.working > 0 then
+      return agent_deck.get_status_icon "working" .. counts.working
+    end
+    return ""
+  end
+
+  -- stackWez.lua disables stack.wez's own enrich_tab_title (same
+  -- format-tab-title race as agent-deck); stack_info() is a stateless
+  -- public function, safe to call directly here.
+  local function stack_tab_indicator(tab)
+    local info = stack.stack_info(tab.tab_id)
+    if not info then
+      return ""
+    end
+    return " [" .. info.index .. "/" .. info.count .. "]"
+  end
 
   tabline.setup {
     options = {
@@ -8,7 +78,24 @@ return function(wezterm, config)
     sections = {
       tabline_a = { "mode" },
       tabline_b = { "workspace" },
-      tabline_x = {},
+      -- Defaults from tabline.wez's config.lua, with the agent-deck icon
+      -- prepended and the stack.wez position suffixed.
+      tab_active = {
+        agent_tab_icon,
+        "index",
+        { "parent", padding = 0 },
+        "/",
+        { "cwd", padding = { left = 0, right = 1 } },
+        { "zoomed", padding = 0 },
+        stack_tab_indicator,
+      },
+      tab_inactive = {
+        agent_tab_icon,
+        "index",
+        { "process", padding = { left = 0, right = 1 } },
+        stack_tab_indicator,
+      },
+      tabline_x = { agent_status_summary },
       tabline_y = { "hostname" },
       tabline_z = { "domain" },
     },

--- a/config/home/gui/emulators/wezterm/wezterm.lua
+++ b/config/home/gui/emulators/wezterm/wezterm.lua
@@ -6,6 +6,9 @@ require "binds"(wezterm, config)
 require "smartSplits"(wezterm, config)
 require "sessions"(wezterm, config)
 require "workspacePicker"(wezterm, config)
+require "agentDeck"(wezterm, config)
+require "agentCards"(wezterm, config)
+require "stackWez"(wezterm, config)
 require "tabline"(wezterm, config)
 
 return config

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -5,6 +5,8 @@
   base16Scheme,
   ...
 }: let
+  sources = pkgs.callPackage ../../../pkgs/_sources/generated.nix {};
+
   # Render a wezterm color scheme TOML from the shared palette.
   # See https://wezterm.org/config/appearance.html#defining-your-own-colors
   # for the schema. ansi[0..7] / brights[0..7] follow the canonical
@@ -67,7 +69,7 @@
 
   # We enumerate files individually (instead of a recursive symlink tree) so
   # the nix-generated colors/cyberpunk.toml can coexist without conflicts.
-  weztermFiles = ["binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
+  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
 in {
   programs.wezterm = {
     enable = true;
@@ -118,7 +120,17 @@ in {
     };
   };
 
-  home.packages = [pkgs.wezterm.terminfo];
+  # python3: runs wezterm-agent-cards' sidebar.py curses TUI (agentCards.lua).
+  home.packages = [pkgs.wezterm.terminfo pkgs.python3];
+
+  # wezterm-agent-cards is both a WezTerm module and a Claude Code plugin —
+  # it isn't installable via wezterm.plugin.require (WezTerm's own plugin
+  # manager), so it's vendored here at the path Claude Code plugins
+  # conventionally live at. agentCards.lua loads wezterm/init.lua from this
+  # path via dofile. The Claude Code side (enabling the plugin in
+  # ~/.claude/settings.json) is NOT managed by this repo — that file is
+  # owned by whichever repo actually manages ~/.claude (not term-nixCfg).
+  home.file.".claude/plugins/wezterm-agent-cards".source = sources.wezterm-agent-cards.src;
 
   xdg.configFile =
     (builtins.listToAttrs (map

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -62,6 +62,27 @@
         },
         "version": "05af76daa2487575b93a4f604693b00969f19c2f"
     },
+    "wezterm-agent-cards": {
+        "cargoLock": null,
+        "date": "2026-03-04",
+        "extract": null,
+        "name": "wezterm-agent-cards",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "wrock",
+            "repo": "wezterm-agent-cards",
+            "rev": "9e9b248fa64f7506bd031d081d21409bf494e5b2",
+            "sha256": "sha256-vOBVx5tHrUcxFmkuaHnd/klGIqurbKVBGKF2x3iUTCI=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "9e9b248fa64f7506bd031d081d21409bf494e5b2"
+    },
     "zellij-harpoon": {
         "cargoLock": null,
         "date": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -39,6 +39,18 @@
     };
     date = "2025-09-24";
   };
+  wezterm-agent-cards = {
+    pname = "wezterm-agent-cards";
+    version = "9e9b248fa64f7506bd031d081d21409bf494e5b2";
+    src = fetchFromGitHub {
+      owner = "wrock";
+      repo = "wezterm-agent-cards";
+      rev = "9e9b248fa64f7506bd031d081d21409bf494e5b2";
+      fetchSubmodules = false;
+      sha256 = "sha256-vOBVx5tHrUcxFmkuaHnd/klGIqurbKVBGKF2x3iUTCI=";
+    };
+    date = "2026-03-04";
+  };
   zellij-harpoon = {
     pname = "zellij-harpoon";
     version = "v0.3.0";

--- a/pkgs/nvfetcher.toml
+++ b/pkgs/nvfetcher.toml
@@ -29,3 +29,11 @@ fetch.github = "dcolinmorgan/herdr-remote"
 [herdr-splits]
 src.git = "https://github.com/lmilojevicc/herdr-splits.nvim"
 fetch.github = "lmilojevicc/herdr-splits.nvim"
+
+# No tagged releases; tracks master HEAD. Not a wezterm.plugin.require
+# package (WezTerm's own plugin manager can't install it — it's also a
+# Claude Code plugin, installed by convention under ~/.claude/plugins/).
+# Vendored declaratively via home.file in config/home/gui/wezterm.nix.
+[wezterm-agent-cards]
+src.git = "https://github.com/wrock/wezterm-agent-cards"
+fetch.github = "wrock/wezterm-agent-cards"


### PR DESCRIPTION
## Summary
- `stackWez.lua`: `stack.wez` pane stacking — `LEADER+c` spawn, `LEADER+u/e` step (staying zoomed), `LEADER+a` fuzzy pane switcher.
- `agentDeck.lua`: `wezterm-agent-deck` for per-pane agent state detection. Its own `tab_title`/`right_status` rendering is disabled (it loses a handler-registration race to `tabline.lua`, which renders instead), and its OS notifications are suppressed when `wezterm-agent-cards` is present.
- `agentCards.lua`: vendors `wrock/wezterm-agent-cards` (new nvfetcher source pin) — it's both a WezTerm module and a Claude Code plugin, not installable via `wezterm.plugin.require`, so it's placed at `~/.claude/plugins/wezterm-agent-cards` via `home.file` and loaded through `dofile` with a `pcall` guard so a missing/broken vendor tree never breaks the rest of the config. Needs `python3` for its sidebar TUI. Note: the Claude Code side (enabling the plugin in `~/.claude/settings.json`) is **not** managed by this repo.
- `tabline.lua`: composes agent-deck's per-pane status icons and stack.wez's stack position into `tab_active`/`tab_inactive`/`tabline_x`.

Stacked on #42 (workspace/tab pickers). Diff shown here is only this PR's slice — `pkgs/_sources/generated.{json,nix}` changes were produced by running `nvfetcher -f wezterm-agent-cards --keep-old` so only the new package's pin is touched.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`
- [ ] `LEADER+c/u/e/a` stack/step/switch panes
- [ ] Run an agent (e.g. Claude Code) in a pane, confirm the tab icon and status summary update
- [ ] Confirm `~/.claude/plugins/wezterm-agent-cards` is populated after activation