### PR TITLE
feat(wezterm): add smart_ssh fuzzy host picker

### DIFF
--- a/config/home/gui/emulators/wezterm/smartSsh.lua
+++ b/config/home/gui/emulators/wezterm/smartSsh.lua
@@ -1,0 +1,16 @@
+return function(wezterm, config)
+  local smart_ssh = wezterm.plugin.require "https://github.com/DavidRR-F/smart_ssh.wezterm"
+
+  config.keys = config.keys or {}
+
+  -- LEADER+s is already a plain (non-ssh) split in binds.lua; the
+  -- shift-cased variant here is the ssh-picker equivalent.
+  table.insert(config.keys, { mods = "LEADER", key = "S", action = smart_ssh.tab() })
+
+  -- apply_to_config sets config.ssh_domains from wezterm.enumerate_ssh_hosts()
+  -- (reading ~/.ssh/config) — Config::ssh_domains() REPLACES (not merges)
+  -- WezTerm's built-in default ssh_domains auto-discovery, so this must
+  -- stay the only place config.ssh_domains is set. Called last per
+  -- upstream's note to call apply_to_config after keys are set.
+  smart_ssh.apply_to_config(config)
+end

--- a/config/home/gui/emulators/wezterm/tabline.lua
+++ b/config/home/gui/emulators/wezterm/tabline.lua
@@ -99,6 +99,28 @@ return function(wezterm, config)
       tabline_y = { "hostname" },
       tabline_z = { "domain" },
     },
+    -- smart_ssh.wezterm has first-class tabline.wez support: while its
+    -- fuzzy host picker is open, tabline_a temporarily shows " SSH "
+    -- instead of the mode indicator, reverting automatically on
+    -- selection/cancel. This is tabline's own extension mechanism
+    -- (temporary sections override, scoped to show/hide events) — not the
+    -- ad-hoc composition used for agent-deck/stack.wez above, since this
+    -- one doesn't touch format-tab-title/update-status at all.
+    extensions = {
+      {
+        "smart_ssh",
+        events = {
+          show = "smart_ssh.fuzzy_selector.opened",
+          hide = {
+            "smart_ssh.fuzzy_selector.canceled",
+            "smart_ssh.fuzzy_selector.selected",
+          },
+        },
+        sections = {
+          tabline_a = { " SSH " },
+        },
+      },
+    },
   }
 
   config.tab_bar_at_bottom = true

--- a/config/home/gui/emulators/wezterm/wezterm.lua
+++ b/config/home/gui/emulators/wezterm/wezterm.lua
@@ -9,6 +9,7 @@ require "workspacePicker"(wezterm, config)
 require "agentDeck"(wezterm, config)
 require "agentCards"(wezterm, config)
 require "stackWez"(wezterm, config)
+require "smartSsh"(wezterm, config)
 require "tabline"(wezterm, config)
 
 return config

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -69,7 +69,7 @@
 
   # We enumerate files individually (instead of a recursive symlink tree) so
   # the nix-generated colors/cyberpunk.toml can coexist without conflicts.
-  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
+  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "smartSsh.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
 in {
   programs.wezterm = {
     enable = true;


### PR DESCRIPTION
## Summary
- `LEADER+S` opens `smart_ssh.wezterm`'s fuzzy picker over hosts read from `~/.ssh/config` (`wezterm.enumerate_ssh_hosts()`).
- `smart_ssh.apply_to_config` sets `config.ssh_domains` from that enumeration — note this **replaces** (not merges with) WezTerm's built-in `ssh_domains` auto-discovery, so this needs to stay the only place `config.ssh_domains` is set.
- `tabline.lua` shows a temporary `" SSH "` indicator in `tabline_a` while the picker is open, using smart_ssh's first-class tabline.wez extension (show/hide events), separate from the ad-hoc agent-deck/stack.wez composition added in the previous PR.

Stacked on #43 (pane stacking + agent monitoring). Diff shown here is only this PR's slice.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`
- [ ] `LEADER+S` opens the fuzzy ssh picker and connects to a host from `~/.ssh/config`
- [ ] Confirm tabline shows " SSH " while the picker is open