### PR TITLE
feat(wezterm): add wezterm-cmdpicker command palette

### DIFF
--- a/config/home/gui/emulators/wezterm/cmdPicker.lua
+++ b/config/home/gui/emulators/wezterm/cmdPicker.lua
@@ -1,0 +1,14 @@
+return function(wezterm, config)
+  local cmdpicker = wezterm.plugin.require "https://github.com/abidibo/wezterm-cmdpicker"
+
+  -- LEADER+Space is already RotatePanes in binds.lua, and cmdpicker's own
+  -- default trigger is that same chord — rebound to LEADER+p. Must be
+  -- required last in wezterm.lua: apply_to_config snapshots config.keys at
+  -- call time to build the picker's auto-discovered "config bindings"
+  -- layer, so every other module's keys need to already be in place.
+  cmdpicker.apply_to_config(config, {
+    key = "p",
+    mods = "LEADER",
+    title = "Command Palette",
+  })
+end

--- a/config/home/gui/emulators/wezterm/wezterm.lua
+++ b/config/home/gui/emulators/wezterm/wezterm.lua
@@ -11,5 +11,6 @@ require "agentCards"(wezterm, config)
 require "stackWez"(wezterm, config)
 require "smartSsh"(wezterm, config)
 require "tabline"(wezterm, config)
+require "cmdPicker"(wezterm, config)
 
 return config

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -69,7 +69,7 @@
 
   # We enumerate files individually (instead of a recursive symlink tree) so
   # the nix-generated colors/cyberpunk.toml can coexist without conflicts.
-  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "options.lua" "sessions.lua" "smartSplits.lua" "smartSsh.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
+  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "cmdPicker.lua" "options.lua" "sessions.lua" "smartSplits.lua" "smartSsh.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
 in {
   programs.wezterm = {
     enable = true;


### PR DESCRIPTION
## Summary
- `LEADER+p` opens `wezterm-cmdpicker`'s command palette — rebound off its default `LEADER+Space`, which `binds.lua` already claims for `RotatePanes`.
- `cmdPicker.lua` must stay the last `require` in `wezterm.lua`: `apply_to_config` snapshots `config.keys` at call time to build its auto-discovered "config bindings" picker layer, so every other module's keys need to already be registered.

Stacked on #44 (smart ssh picker) — last of the plugin PRs before the quake terminal one. Diff shown here is only this PR's slice.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`
- [ ] `LEADER+p` opens the command palette and lists other modules' keybindings