### PR TITLE
feat(wezterm): tag quake-workspace windows with a stable title

### DIFF
--- a/config/home/gui/emulators/wezterm/quakeTerm.lua
+++ b/config/home/gui/emulators/wezterm/quakeTerm.lua
@@ -1,0 +1,14 @@
+-- Tags windows opened in the "quake" workspace (`wezterm start --domain
+-- local-mux --attach --workspace quake`) with a stable OS window title.
+-- macOS has no X11/Wayland-style window class to match on, so the
+-- Hammerspoon toggle (hammerspoon-nix repo, myCfg/WindowManager/quakeTerm.lua)
+-- and Sway's app_id-based scratchpad rule (infra-nixCfg repo,
+-- home/gui/linux/sway/quakeTerm.nix) both rely on `--class wezterm-quake`
+-- for identification on Linux, while this title is what macOS matches on.
+return function(wezterm, config)
+  wezterm.on("format-window-title", function(tab, pane, tabs, panes, cfg)
+    if wezterm.mux.get_active_workspace() == "quake" then
+      return "wezterm-quake"
+    end
+  end)
+end

--- a/config/home/gui/emulators/wezterm/wezterm.lua
+++ b/config/home/gui/emulators/wezterm/wezterm.lua
@@ -10,6 +10,7 @@ require "agentDeck"(wezterm, config)
 require "agentCards"(wezterm, config)
 require "stackWez"(wezterm, config)
 require "smartSsh"(wezterm, config)
+require "quakeTerm"(wezterm, config)
 require "tabline"(wezterm, config)
 require "cmdPicker"(wezterm, config)
 

--- a/config/home/gui/wezterm.nix
+++ b/config/home/gui/wezterm.nix
@@ -69,7 +69,7 @@
 
   # We enumerate files individually (instead of a recursive symlink tree) so
   # the nix-generated colors/cyberpunk.toml can coexist without conflicts.
-  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "cmdPicker.lua" "options.lua" "sessions.lua" "smartSplits.lua" "smartSsh.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
+  weztermFiles = ["agentCards.lua" "agentDeck.lua" "binds.lua" "cmdPicker.lua" "options.lua" "quakeTerm.lua" "sessions.lua" "smartSplits.lua" "smartSsh.lua" "stackWez.lua" "tabline.lua" "wezterm.lua" "workspacePicker.lua"];
 in {
   programs.wezterm = {
     enable = true;


### PR DESCRIPTION
## Summary
- `format-window-title` returns `"wezterm-quake"` for any window in the `"quake"` mux workspace (started via `wezterm start --domain local-mux --attach --workspace quake`).
- macOS has no X11/Wayland-style window class to match on, so a Hammerspoon dropdown-terminal toggle (in `hammerspoon-nix`) matches on this title. Linux dropdown toggles match on `--class wezterm-quake` at spawn time instead (in `infra-nixCfg`'s Sway config) — this file only owns the macOS-side title tagging.
- Cross-repo coupling is by string convention only (`"quake"` workspace name / `"wezterm-quake"` title / `--class wezterm-quake`), not a hard dependency — flagging for reviewer awareness since neither of the other repos is touched by this PR.

Last PR in the stack, on top of #45 (command palette). Diff shown here is only this PR's slice.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch`
- [ ] `wezterm start --domain local-mux --attach --workspace quake`, confirm the OS window title is `wezterm-quake`
- [ ] Confirm the Hammerspoon toggle (separate repo) still matches the window